### PR TITLE
Bugfix: Ledger Deadlock

### DIFF
--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -542,10 +542,10 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         } else if unconfirmed_block_height == self.canon.latest_block_height() + 1
             && unconfirmed_previous_block_hash == self.canon.latest_block_hash()
         {
-            // Acquire the lock for the canon chain.
-            let _canon_lock = self.canon_lock.lock().await;
             // Acquire the lock for block requests.
             let _block_requests_lock = self.block_requests_lock.lock().await;
+            // Acquire the lock for the canon chain.
+            let _canon_lock = self.canon_lock.lock().await;
 
             // Ensure the block height is not part of a block request on a fork.
             let mut is_block_on_fork = false;


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

The `canon_lock` and `block_requests_lock` within `Ledger` have a chance to become deadlock.

There are three parallel scenarios:

### Scenario One

`self.update_ledger(&prover_router).await;` ([src/network/ledger.rs#L286](
https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L286))

-->

`let _block_request_lock = self.block_requests_lock.lock().await;` ([src/network/ledger.rs#L441](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L441))

-->

`self.revert_to_block_height(self.canon.latest_block_height().saturating_sub(1))` ([src/network/ledger.rs#L456](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L456))

-->

`let _canon_lock = self.canon_lock.lock().await;` ([src/network/ledger.rs#L621](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L621))

### Scenario Two

`self.update_block_requests().await;` ([src/network/ledger.rs#L272](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L272))

-->

`let _block_requests_lock = self.block_requests_lock.lock().await;` ([src/network/ledger.rs#L858](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L858))

-->

`if latest_block_height != maximum_common_ancestor && !self.revert_to_block_height(maximum_common_ancestor).await {` ([src/network/ledger.rs#L920](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L920))

-->

`let _canon_lock = self.canon_lock.lock().await;` ([src/network/ledger.rs#L621](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L621))

### Scenario Three

{
`self.add_block(block, &prover_router).await;` ([src/network/ledger.rs#L261](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L261))

OR

`self.add_block(block.clone(), &prover_router).await;` ([src/network/ledger.rs#L318](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L318))
}

-->

`let _canon_lock = self.canon_lock.lock().await;` ([src/network/ledger.rs#L546](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L546))

-->

`let _block_requests_lock = self.block_requests_lock.lock().await;` ([src/network/ledger.rs#L548](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L548))

## Test Plan

<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

According to the above scenarios, it is possible to form a deadlock like this:

```
# Thread 1
self.block_requests_lock.lock().await

# Thread 2
self.canon_lock.lock().await

# Thread 1
self.canon_lock.lock().await

# Thread 2
self.block_requests_lock.lock().await
```

## Solution

The way to prevent such deadlock is simple:

Modify the code within `async fn add_block(&self, unconfirmed_block: Block<N>, prover_router: &ProverRouter<N>) -> bool` ([src/network/ledger.rs#L527](https://github.com/AleoHQ/snarkOS/blob/4595f0a11ac5ba7a4956c3a77ea6c90bd86eddee/src/network/ledger.rs#L527)).

Ensure that `block_requests_lock.lock().await` is used ahead of `canon_lock.lock().await`.

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/snarkOS,
    and link to your PR here.
-->

Not yet.
